### PR TITLE
Fix subkeys problem

### DIFF
--- a/bzts3reader/s3reader.py
+++ b/bzts3reader/s3reader.py
@@ -6,6 +6,7 @@ from botocore.exceptions import NoCredentialsError, ClientError
 from bzt import TaurusConfigError
 from bzt.engine import Service
 
+import os
 
 class S3Reader(Service):
     def __init__(self):
@@ -23,9 +24,9 @@ class S3Reader(Service):
         if not self.file_name:
             raise TaurusConfigError("file not found in settings")
         s3 = boto3.resource('s3')
-        bucket = s3.Bucket(self.bucket_name)
         try:
-            bucket.download_file(self.file_name, f'./{self.file_name}')
+            _, file_name = os.path.split(self.file_name) # Decoupling file itself from subkeys
+            s3.meta.client.download_file(self.bucket_name, self.file_name, file_name) # Downloading the file without subkeys
         except (NoCredentialsError, ClientError) as err:
             raise TaurusConfigError(f'Error while downloading file {self.file_name} from {self.bucket_name}: {err}, check https://github.com/cezkuj/bzt-s3-reader#aws-authentication')
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="bzt-s3-reader",
-    version="0.0.0",
+    version="0.1.0",
     author="Cezary Kujawski",
     author_email="cezkuj@gmail.com",
     license="Apache License 2.0",


### PR DESCRIPTION
If filename has subkeys, like here: 
```
    s3reader:
      #required
      bucket: my_awesome_bucket
      #required
      file: my_ammo/17.08.2022/13:38:44/ammo_id_offers.txt
```
the plugin will be complaining `file not found`.

It's better to use another boto3 method to work with subdirs. 